### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Set-up steps:
    * On Windows, you need to `install the mbed driver
      <https://developer.mbed.org/handbook/Windows-serial-configuration>`__.
 
-2. `Install Jupyter <http://jupyter.readthedocs.org/en/latest/install.html>`__.
-3. Install this package::
+3. `Install Jupyter <http://jupyter.readthedocs.org/en/latest/install.html>`__.
+4. Install this package::
 
        pip install ubit_kernel
        python3 -m ubit_kernel.install


### PR DESCRIPTION
Based on your work, I've derived support for communicating with micropython on a NodeMcu over a serial line. It's basically just changing the USB VID and PID to make it work and updating all names to reflect the different board. It's fun to see that the NodeMcu behaves exactly like the BBC micro:bit. 

Find the nodemcu_kernel here: https://github.com/jneines/nodemcu_kernel/

When updating all corresponding files i've gotten aware of a trivial typo in your Readme file, which i've fixed along with this pull request.

Fixed item numbering in the Readme file